### PR TITLE
BulkMail fails to retrieve items in index 13 through 16

### DIFF
--- a/BulkMailInbox.lua
+++ b/BulkMailInbox.lua
@@ -129,7 +129,7 @@ local function inboxCacheBuild()
             if isGM or not canReply or _isAHSentMail(subject) then
                 canReturnItem = false
             end
-            for j=1, ATTACHMENTS_MAX_SEND do
+            for j=1, ATTACHMENTS_MAX_RECEIVE do
                 if GetInboxItem(i,j) and _matchesFilter(GetInboxItem(i, j)) then
                     table.insert(inboxCache, newHash(
                             'index', i, 'attachment', j, 'sender', sender, 'bmid', daysLeft..subject..j, 'returnable', canReturnItem, 'cod', cod,
@@ -442,7 +442,7 @@ function mod:TakeNextItemFromMailbox()
         subject = prevSubject
     end
 
-    if curAttachIndex == ATTACHMENTS_MAX_SEND then
+    if curAttachIndex == ATTACHMENTS_MAX_RECEIVE then
         ibIndex = ibIndex - 1
         ibAttachIndex = 0
     else


### PR DESCRIPTION
BulkMail fails to retrieve items in index 13 through 16 changed ATTACHMENTS_MAX_SEND to ATTACHMENTS_MAX_RECEIVE

Issue:
https://github.com/neotron/WoW-BulkMail-Inbox/issues/16